### PR TITLE
Update Twilio Voice Android to 6.0.2

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020 Denis Kornev
+Copyright (c) 2021 Xamarin Binding Community for Twilio
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -4,12 +4,12 @@ Twilio Voice Android SDK binding for Xamarin
 
 [![NuGet][nuget-img]][nuget-link]
 
-[nuget-img]: https://img.shields.io/badge/nuget-6.0.0-blue.svg
+[nuget-img]: https://img.shields.io/badge/nuget-6.0.2-blue.svg
 [nuget-link]: https://www.nuget.org/packages/Twilio.Voice.Android.XamarinBinding
 
 ## How to Build
 
-### Twilio.Voice Android 6.0.0 (November 2nd, 2021)
+### Twilio.Voice Android 6.0.2 (November 19nd, 2021)
 
 _Xbindings.ReLinker.Droid_ NuGet package needs to be added into your Android project.
 I'll add it as a dependency later.

--- a/README.md
+++ b/README.md
@@ -4,12 +4,12 @@ Twilio Voice Android SDK binding for Xamarin
 
 [![NuGet][nuget-img]][nuget-link]
 
-[nuget-img]: https://img.shields.io/badge/nuget-5.4.0-blue.svg
+[nuget-img]: https://img.shields.io/badge/nuget-6.0.0-blue.svg
 [nuget-link]: https://www.nuget.org/packages/Twilio.Voice.Android.XamarinBinding
 
 ## How to Build
 
-### Twilio.Voice Android 5.4.0 (July 9th, 2020)
+### Twilio.Voice Android 6.0.0 (November 2nd, 2021)
 
 _Xbindings.ReLinker.Droid_ NuGet package needs to be added into your Android project.
 I'll add it as a dependency later.
@@ -30,26 +30,13 @@ Download aar/jar version you needed from https://bintray.com/twilio/releases/voi
 -keep class com.twilio.voice.** { *; }
 -keepattributes InnerClasses
 
--dontwarn okio.**
--dontwarn retrofit.**
--keep class retrofit.** { *; }
--keepclassmembers,allowobfuscation interface * {
-@retrofit.http.** <methods>;
-}
-
--dontwarn com.squareup.okhttp.**
-
 ## Sample
 
-####  I don't have C# version of twilio quickstart application, so I highly recommend you to read about using native library bindings for xamarin and check official Twilio quickstart guides.
+####  We don't have C# version of twilio quickstart application, so I highly recommend you to read about using native library bindings for xamarin and check official Twilio quickstart guides.
 
 [voice-quickstart-android](https://github.com/twilio/voice-quickstart-android)
 
 ## Contributions
-
-Members of the community have contributed to improving and update bindings:
-
-- Rob Harwood
 
 If you have a bugfix or an update you'd like to add, please open an issue. 
 All pull requests should be opened against the `master` branch.

--- a/src/Twilio.Voice.Android.csproj
+++ b/src/Twilio.Voice.Android.csproj
@@ -12,7 +12,7 @@
     <RootNamespace>TwilioVoice.Android</RootNamespace>
     <AssemblyName>TwilioVoice.Android</AssemblyName>
     <FileAlignment>512</FileAlignment>
-    <TargetFrameworkVersion>v9.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v11.0</TargetFrameworkVersion>
     <AndroidClassParser>class-parse</AndroidClassParser>
   </PropertyGroup>
   <PropertyGroup Condition="$(Configuration.Contains('Debug'))">
@@ -67,7 +67,7 @@
     <Folder Include="Jars\" />
   </ItemGroup>
   <ItemGroup>
-    <LibraryProjectZip Include="Jars\voice-android-5.6.2.aar" />
+    <LibraryProjectZip Include="Jars\voice-android-6.0.0.aar" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.Bindings.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/src/Twilio.Voice.Android.csproj
+++ b/src/Twilio.Voice.Android.csproj
@@ -67,7 +67,7 @@
     <Folder Include="Jars\" />
   </ItemGroup>
   <ItemGroup>
-    <LibraryProjectZip Include="Jars\voice-android-6.0.0.aar" />
+    <LibraryProjectZip Include="Jars\voice-android-6.0.2.aar" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.Bindings.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/src/Twilio.Voice.Android.csproj
+++ b/src/Twilio.Voice.Android.csproj
@@ -60,7 +60,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Xamarin.ReLinker">
-      <Version>1.4.3</Version>
+      <Version>1.4.4</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/build.sh
+++ b/src/build.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
 msbuild -t:Clean,Build -p:Configuration=Release Twilio.Voice.Android.csproj
-nuget pack twilio-voice.nuspec 
+# nuget pack twilio-voice.nuspec 

--- a/src/twilio-voice.nuspec
+++ b/src/twilio-voice.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>Twilio.Voice.Android.XamarinBinding</id>
-    <version>6.0.0.0</version>
+    <version>6.0.2.0</version>
     <authors>twilio dkornev</authors>
     <owners>twilio</owners>
     <projectUrl>https://github.com/xamarin-bindings-for-twilio/TwilioVoiceXamarinAndroid</projectUrl>

--- a/src/twilio-voice.nuspec
+++ b/src/twilio-voice.nuspec
@@ -2,10 +2,10 @@
 <package >
   <metadata>
     <id>Twilio.Voice.Android.XamarinBinding</id>
-    <version>5.4.0.0</version>
+    <version>6.0.0.0</version>
     <authors>twilio dkornev</authors>
     <owners>twilio</owners>
-    <projectUrl>https://github.com/dkornev/TwilioVoiceXamarinAndroid</projectUrl>
+    <projectUrl>https://github.com/xamarin-bindings-for-twilio/TwilioVoiceXamarinAndroid</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <title>Twilio Voice Android SDK</title>
     <summary>Twilio Voice Android SDK binding for Xamarin Android</summary>
@@ -20,6 +20,6 @@
     <!-- Optional 'files' node -->
     <files>
         <!--Android-->
-        <file src="bin/Release/TwilioVoice.Android.dll" target="lib/MonoAndroid10/TwilioVoice.Android.dll" />
+        <file src="bin/Release/TwilioVoice.Android.dll" target="lib/MonoAndroid11/TwilioVoice.Android.dll" />
     </files>
 </package>


### PR DESCRIPTION
This one updated the Twilio Voice Android binding to the latest 6.0.1 version https://www.twilio.com/docs/voice/sdks/android/3x-changelog#600

I tried to mimic some changes from https://github.com/xamarin-bindings-for-twilio/TwilioVoiceXamarinIOS/pull/1 related to the readme and licensing.
